### PR TITLE
[1.9.4] Update zh_CN.lang. Fix lines going off the edge

### DIFF
--- a/src/main/java/totemic_commons/pokefenn/totempedia/page/PageText.java
+++ b/src/main/java/totemic_commons/pokefenn/totempedia/page/PageText.java
@@ -10,15 +10,11 @@
  */
 package totemic_commons.pokefenn.totempedia.page;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import totemic_commons.pokefenn.client.FontHelper;
 import vazkii.botania.totemic_custom.api.internal.IGuiLexiconEntry;
 import vazkii.botania.totemic_custom.api.lexicon.LexiconPage;
 
@@ -50,51 +46,9 @@ public class PageText extends LexiconPage
         String text = I18n.format(unlocalizedText).replaceAll("&", "\u00a7");
         String[] textEntries = text.split("<br>");
 
-        String lastFormat = "";
-        String pendingFormat = "";
         for(String s : textEntries)
         {
-            List<String> wrappedLines = new ArrayList<>();
-            String workingOn = "";
-
-            int i = 0;
-            String[] tokens = s.split(" ");
-            for(String s1 : tokens)
-            {
-                boolean skipPending = false;
-                String format = FontHelper.getFormatFromString(s1);
-
-                if(!format.isEmpty() && s1.length() > 0 && s1.charAt(0) != '\u00a7')
-                {
-                    skipPending = true;
-                    pendingFormat = format;
-                    format = "";
-                }
-
-                if(!pendingFormat.isEmpty() && !skipPending)
-                {
-                    format = pendingFormat;
-                    pendingFormat = "";
-                }
-
-                if(format == null || format.equals(""))
-                    format = lastFormat;
-
-                if(renderer.getStringWidth(workingOn + " " + s1) >= width)
-                {
-                    wrappedLines.add(workingOn);
-                    workingOn = "";
-                }
-                workingOn = workingOn + format + " " + s1;
-
-                if(i == tokens.length - 1)
-                    wrappedLines.add(workingOn);
-
-                ++i;
-                lastFormat = format;
-            }
-
-            for(String s1 : wrappedLines)
+            for(String s1 : renderer.listFormattedStringToWidth(s, width)) // This method handles both format and line wraps, no need to write one yourself. Fix lines going off the edge.
             {
                 y += 10;
                 renderer.drawString(s1, x, y, 0);
@@ -105,5 +59,4 @@ public class PageText extends LexiconPage
 
         renderer.setUnicodeFlag(unicode);
     }
-
 }

--- a/src/main/resources/assets/totemic/lang/zh_CN.lang
+++ b/src/main/resources/assets/totemic/lang/zh_CN.lang
@@ -2,8 +2,14 @@
 
 # Item localizations
 item.totemic:totemicStaff.name=图腾权杖
+item.totemic:totemicStaff.tooltip=你的图腾需要它!
 item.totemic:totemWhittlingKnife.name=图腾刻刀
 item.totemic:totemWhittlingKnife.display=图腾刻刀 (%s)
+item.totemic:totemWhittlingKnife.tooltip1=制作各种雕刻品必不可少的道具
+item.totemic:totemWhittlingKnife.tooltip2=按住Shift右击或滚动滚轮以改变雕刻的图纹
+item.totemic:totemWhittlingKnife.tooltip3=正在雕刻：%s
+item.totemic:paintBrush.name=图腾研究者的漆刷
+item.totemic:infusedStick.name=红柏木棍
 item.totemic:totempedia.name=图腾百科全书
 item.totemic:flute.name=长笛
 item.totemic:fluteInfused.name=蕴魔长笛
@@ -11,7 +17,14 @@ item.totemic:cedarBark.name=红柏树皮
 item.totemic:barkStripper.name=剥皮器
 item.totemic:jingleDress.name=叮当舞装
 item.totemic:ceremonialRattle.name=摇响器
-
+item.totemic:tipiItem.name=印第安帐篷
+item.totemic:nuggetIron.name=铁粒
+item.totemic:bellsIron.name=铁铃
+item.totemic:buffaloHide.name=野牛牛皮
+item.totemic:buffaloTeeth.name=野牛牙齿
+item.totemic:buffaloMeat.name=野牛肉
+item.totemic:buffaloCookedMeat.name=烤野牛肉
+item.totemic:baykokBow.name=贝柯克之弓
 
 # Block localizations
 tile.cedarLog.name=红柏原木
@@ -24,6 +37,17 @@ tile.windChime.name=风铃
 tile.totemTorch.name=图腾火炬
 tile.redCedarPlank.name=红柏木板
 tile.redCedarStripped.name=剥皮的红柏原木
+tile.totemicTipi.name=印第安帐篷
+tile.dummyTotemicTipi.name=印第安帐篷
+
+#Entity localizations
+entity.totemic.buffalo.name=野牛
+entity.totemic.baykok.name=贝柯克
+
+#Potion effect localizations
+totemic.potion.bat=蝙蝠
+totemic.potion.horse=马
+totemic.potion.spider=蜘蛛
 
 # Creative Tab localizations
 itemGroup.Totemic=图腾
@@ -39,33 +63,67 @@ totemic.melodyName.high=丰富的旋律
 totemic.melodyName.maximum=爆发的旋律
 
 #Ceremony names
-totemic.ceremony.flute=长笛注魔仪式
-totemic.ceremony.ghostDance=鬼舞仪式
-totemic.ceremony.rainDance=祈雨舞仪式
-totemic.ceremony.drought=干旱仪式
-totemic.ceremony.potion=灵药仪式
-totemic.ceremony.buffaloDance=曼丹野牛舞
+totemic.ceremony.totemic:flute=魔域长笛
+totemic.ceremony.totemic:ghostDance=幽灵舞蹈
+totemic.ceremony.totemic:rainDance=祈雨舞蹈
+totemic.ceremony.totemic:drought=干旱仪式
+totemic.ceremony.totemic:potion=神圣炼金剂
+totemic.ceremony.totemic:buffaloDance=曼丹野牛舞
+totemic.ceremony.totemic:zaphkielWaltz=沙法尔圆舞
+totemic.ceremony.totemic:warDance=战争仪式
+totemic.ceremony.totemic:baykokSummon=丧钟仪式
+
+#Totem effect names
+totemic.totem.totemic:horse=马
+totemic.totem.totemic:squid=鱿鱼
+totemic.totem.totemic:blaze=烈焰人
+totemic.totem.totemic:ocelot=豹猫
+totemic.totem.totemic:bat=蝙蝠
+totemic.totem.totemic:spider=蜘蛛
+totemic.totem.totemic:cow=牛
+
+#Music values
+totemic.music.lowMelody=单调的旋律
+totemic.music.mediumMelody=普通的旋律
+totemic.music.highMelody=优美的旋律
+totemic.music.veryHighMelody=非常富饶的旋律
+
+totemic.musicNeeded.none=不需要演奏音乐
+totemic.musicNeeded.little=需要演奏一小段音乐
+totemic.musicNeeded.littleMedium=需要演奏一段音乐
+totemic.musicNeeded.medium=需要演奏中等篇幅的音乐
+totemic.musicNeeded.mediumLarge=需要演奏较长篇幅的音乐
+totemic.musicNeeded.large=需要演奏大量音乐
+totemic.musicNeeded.crazyLarge=需要弹个不停
 
 totemicmisc.timeForCeremony=执行时间:
-totemicmisc.seconds= 秒
+totemicmisc.seconds=秒
 totemicmisc.overTime=持续:
 totemicmisc.capitalFalse=否
 totemicmisc.capitalTrue=是
 totemicmisc.musicSelector=音乐选择器
-totemicmisc.tipi.cantSleep=你不能在非开阔地的帐篷里睡觉
+totemicmisc.tipi.cantSleep=你不能在非开阔地的印第安帐篷里睡觉
 totemicmisc.tipi.nether=你不能在下界睡觉
+totemicmisc.activeEffect=已激活的图腾效果：%s
+totemicmisc.startup=激活中
+totemicmisc.activeCeremony=激活仪式
+totemicmisc.isDoingStartup=该图腾柱正在激活仪式
+totemicmisc.isDoingCeremony=该图腾柱正在散发效果
 
 #Totempedia Localisations
-totemic.gui.lexicon.header=图腾百科全书, 你的所有图腾所需的指南.
+totemic.gui.lexicon.header=图腾百科全书，你的所有图腾所需的指南.
 
-totemicmisc.clickToAdd=点击添加
+totemicmisc.clickToAdd=点击添加书签
 totemicmisc.back=返回
 totemicmisc.clickToSee=点击打开
-totemicmisc.shiftToRemove=Shift点击移除
+totemicmisc.shiftToRemove=按住Shift单击以移除书签
 totemicmisc.nextPage=下一页
 totemicmisc.prevPage=上一页
 totemicmisc.bookmark=书签
 totemicmisc.clickToIndex=点击返回目录
+totemicmisc.clickToRecipe=按住Shift单击以显示配方
+totemicmisc.shapeless=无序
+totemicmisc.oredict=矿物辞典
 
 totemic.category.basics=图腾基础
 totemic.category.devices=装置
@@ -77,55 +135,99 @@ totemic.category.ceremonies=仪式
 totemic.category.instruments=乐器
 
 totemic.entry.cedarTree=红柏树
-totemic.page.cedarTree0=高大无比的红柏树, 最为强壮的生命体, 最富有力量的树木之一. 所有图腾的基座都需要它的原木来制作, 红柏原木还拥有其它原木没有的特性. 想要得到红柏树苗, 你只需要用 &1红柏变形器&0 右键任何树苗.
-totemic.page.cedarTree1=红柏树通常高达6至9格, 但当然它们的高度各异. 红柏树苗会像其它树苗那样掉落, 并和所有普通树苗拥有一样的形态.
+totemic.page.cedarTree0=高大无比的&1红柏树&0有着魔法的属性，所以这种木头作为图腾基座时非常有用，他可以通过使用普通的树苗通过&4沙法尔圆舞仪式&0蕴魔获得。<br>红柏木可以像普通木头那样使用，你也可以使用&4剥皮器&0去除它的树皮。
+totemic.page.cedarTree1=
 
 totemic.entry.buffaloBasic=野牛
-totemic.page.buffaloBasic0=高大威猛的野牛, 它提供的丰富资源与它的威力闻名于这片大陆. 在主世界的任何地带都能找到它们, 或之后通过一种仪式来"创造". 野牛们极为强健, 并且有很高的生命值.
+totemic.page.buffaloBasic0=强壮威猛的野牛，它可提供的丰富资源与其威力闻名于这片大陆。野牛们极为强健，并且有很高的生命值。由于不断的狩猎，野牛已经濒临灭绝了，然而你仍可以使用&4曼丹野牛舞&0生成它。
+totemic.page.buffaloBasic1=
 
 totemic.entry.creatingTotems=图腾柱
-totemic.page.creatingTotems0=制作一个图腾柱再简单不过了. 首先你需要制作一把 &1图腾刻刀&0, 这将是你用来雕刻图腾的工具.
+totemic.page.creatingTotems0=制作一个图腾柱再简单不过了。首先你需要制作一把&1图腾刻刀&0。这将是你在图腾柱上进行雕刻的工具。
+totemic.page.creatingTotems1=&1图腾基座&0也需要用刻刀雕刻制作。你可以把图腾柱建造至6格高。但别忘了在最底下放上图腾基座。<br>通常图腾柱会给予所有附近玩家一些有益的&4效果&0，至于是何种效果则需要根据雕刻的图纹来决定。一个图腾柱的每格都能拥有不同的图纹。
+totemic.page.creatingTotems2=
+
+totemic.entry.totemEffects=图腾效果
+totemic.page.totemEffects0=雕刻图腾柱可以使它赋予你各种效果：<br>&1马&0：带来速度提升的效果<br>&1鱿鱼&0：带来水下呼吸的能力<br>&1烈焰人&0：带来火焰抗性<br>&1豹猫&0：带来阻止爬行者爆炸的效果
+totemic.page.totemEffects1=&1蝙蝠&0：让你免疫掉落伤害，让你可以在半空中潜行向前滑行<br>&1蜘蛛&0：让你能够像一只蜘蛛一样爬墙<br>&1牛&0：带来减轻伤害的效果，但会让你的身体变沉
 
 totemic.entry.instruments=乐器
-totemic.page.instruments0=乐器可以制造 &4音乐旋律&0, 音乐旋律可以给图腾系统和一些方块提供能量, 例如 &1图腾基座&0 以及 &4仪式&0. 当乐器奏响时, 它们会向最近的可接收方块传输旋律. 每种乐器都能以不同的方式制造 &4音乐旋律&0 , 每种乐器演奏出的旋律传输方式和传输范围也大同小异.
+totemic.page.instruments0=乐器可以奏出&4音乐旋律&0，这些旋律是&1图腾基座&0的生命。当乐器奏响时，它们的旋律会浸入任何接收者内。每种乐器奏出的&4音乐旋律&0都有所不同，比如说在于其强度、传递范围、以及图腾可接收的量。
+totemic.page.instruments1=
 
 totemic.entry.windChime=风铃
-totemic.page.windChime0=&1风铃&0 是一种能在风中摇动, 并在起风时偶尔奏出 &4音乐旋律&0 的乐器, 包括所有临近的 &1风铃&0. &1风铃&0 的下方不能放置任何方块, 并且上方必须有一个方块来使其悬挂, 不然它将会掉下. 尽管 &1风铃&0 不能制造大量的 &4音乐旋律&0, 但它不需要玩家来演奏.
-totemic.page.windChime1=悬挂在树枝上的 &1风铃&0 并不少见, 甚至有传言说这些风铃能制造出更大量的音乐旋律. 当 &1风铃&0 奏响时, 它将使劲的摇动并奏响音乐. 由于 &1风铃&0 很容易制造音乐, 所以当每个风铃制造的 &4音乐旋律&0 到达最大量之前都不需要挂太多.
+totemic.page.windChime0=&1风铃&0是一种能在风中摇动。并在起风时偶尔奏出&4音乐旋律&0的乐器。&1风铃&0的下方不能放置任何方块。并且它必须悬挂在其顶部的一个方块上，要不然就掉下来了。尽管&1风铃&0不能制造大量的&4音乐旋律&0，但它不需要玩家来演奏。
+totemic.page.windChime1=悬挂在树枝上的&1风铃&0并不少见，甚至传说这些风铃能制造出更丰富的旋律。&1风铃&0奏响时，你会看到它使劲的摇动并发出声音。由于&1风铃&0很容易产生音乐，所以不多的风铃就能达到最大量的&4音乐旋律&0。
+totemic.page.windChime2=
 
 totemic.entry.drum=鼓
-totemic.page.drum0= &1鼓&0 是一种只要用任意拳头猛击就可以奏响的乐器. 由于每次敲击鼓面后都需要时间来进行反应, 所以每次敲击奏响后都会有一秒的间隔才可以奏响第二次. 鼓奏出的节拍通常是恒定不变的, 它也是仪式的重要组成部分, 因为它奏出的音乐都相当有旋律. 当潜行时敲击会选择并执行 &4仪式&0 .
+totemic.page.drum0=&1鼓&0是一种只要用拳头猛击就可以演奏的乐器。由于每次敲击鼓面后都需要一定时间，所以每次敲击奏响后都会有一秒的间隔才可以奏响第二次。鼓奏出的节拍通常是恒定不变的，它也是仪式的重要组成部分，因为它奏出的音乐都相当有旋律。和其他乐器一样，当潜行时敲击可以选择&4仪式&0。
+totemic.page.drum1=
 
 totemic.entry.jingleDress=叮当舞装
-totemic.page.jingleDress0=&1叮当舞装&0. &4图腾族&0 中最有名的着装之一. 它是件由树叶制成的服装, 上面挂着一些铃铛. 穿上它到处跑就能向附近的图腾传输音乐旋律. 有人说你跑的越快就能制造更大量的音乐, 如果你饮用了速度药水, 它所制造出的音乐会加十倍! 穿上叮当舞装潜行时仍然会制造出音乐.
-totemic.page.jingleDress1=叮当舞装能制造出丰富的旋律, 这就意味着如果使用得当它就能制造出大量音乐旋律, 理所应当的 &1图腾&0 就能从中接收到更大量的 &4音乐旋律&0 .
+totemic.page.jingleDress0=&1叮当舞装&0，&4图腾族&0中最有名的着装之一。它是件由树叶制成的裙子，上面挂着一些铃铛。穿上它到处跑就能向附近的图腾柱传输音乐旋律。有人说你跑的越快就能制造更大量的音乐。如果你饮用了速度药水。它所制造出的音乐会加十倍！
+totemic.page.jingleDress1=叮当舞装能制造出丰富的旋律。这就意味着如果使用得当它就能制造出大量音乐旋律，&1图腾&0就能从中接收到更大量的&4音乐旋律&0。
+totemic.page.jingleDress2=
+totemic.page.jingleDress3=
 
 totemic.entry.flute=长笛
-totemic.page.flute0=&1长笛&0, 这片大陆上人人皆知的乐器, 它简便而有效. 它是一种使用起来极其简单的乐器. 但因为它的简单, 它是否是最富有旋律的乐器, 以及能有多少 &4图腾&0 可以接收它的旋律, 以及 &1长笛&0 能产生多大的吹风我们都不得而知. 但于其它乐器一样, 当潜行时演奏能使附近的 &4图腾&0 执行仪式.
+totemic.page.flute0=&1长笛&0，这片大陆上人人皆知的乐器，它简便而有效。它是一种使用起来极其简单的乐器。但因为它的简单，它是否是最富有旋律的乐器，以及能有多少&4图腾&0可以接收它的旋律，以及&1长笛&0能产生多大的吹风我们都不得而知。当潜行时演奏能为附近的&4图腾柱&0选择&4仪式&0。
+totemic.page.flute1=&1长笛&0还可通过&4魔域长笛仪式&0蕴魔获得其他属性。
+totemic.page.flute2=
 
 totemic.entry.rattle=摇响器
-totemic.page.rattle0=&1摇响器&0 , 从图腾族被人发现至今都是仪式中的骨干乐器. 无论何时用左手握住 &1摇响器&0 都能制造出 &4音乐旋律&0 . 现在我们还未得知它是否会产生仪式效果, 但相信有一天我们能发现. 和其它乐器一样, 它能在潜行时演奏.
+totemic.page.rattle0=&1摇响器&0，从图腾族被人发现至今都是仪式中的骨干乐器。无论何时用手握住&1摇响器&0都能制造出&4音乐旋律&0。现在我们还未得知它是否会产生更多仪式效果，但相信有一天我们能发现。和其它乐器一样，它能在潜行时演奏以激活仪式。
+totemic.page.rattle1=像其它乐器一样，当潜行时演奏可以激活仪式。
+totemic.page.rattle2=
 
 totemic.entry.performingCeremonies=执行仪式
-totemic.page.performingCeremonies0=&4仪式&0 能通过音乐的力量使图腾族在一段时间内获得力量, 并通过一些操作来释放特定的仪式效果. &4仪式&0 的核心是一个 &1图腾基座&0, 所有音乐或其它能量都会在 &1图腾柱&0 上聚集, 并在那里释放出仪式效果.
-totemic.page.performingCeremonies1=要执行一个 &4仪式&0, 必须注意几件事. 选择并创建你的 &4仪式&0, 你必须在选择模式下演奏4种乐器, 以此来选择要传送音乐的 &1图腾柱&0. 要在选择模式下演奏多种乐器, 只需要潜行并像往常一样演奏它们. 当你演奏完4种与 &4仪式&0 相应的乐器后, 仪式将开始执行创建.
-totemic.page.performingCeremonies2=当仪式处于执行创建状态, &1图腾柱&0 会接收附近的音乐并储存它们. 这些音乐就叫做 &4音乐旋律&0 , 它就是激活 &4仪式&0 所需的能量. 当 &4音乐旋律&0 达到 &4仪式&0 所需旋律的上限值, 仪式就执行完成并从图腾产生仪式效果. 每个乐器有各自演奏的上限程度, 所以执行任何仪式都不能只由一个乐器来演奏.
-totemic.page.performingCeremonies3=并非所有 &4仪式&0 都会在执行完成后立即结束. 相反的, 一些执行后产生的仪式效果会一直持续直到特定时间. 仪式效果的持续也会让 &4音乐旋律&0 持续消耗. 注意, 仪式效果在持续到特定的时间过后就会消失.
+totemic.page.performingCeremonies0=&4仪式&0能通过音乐的力量使图腾族在一段时间内获得力量，并通过一些操作来释放特定的仪式效果。&4仪式&0的中心是一个&1图腾基座&0，所有音乐或其它能量都会在&1图腾柱&0上聚集，并在那里释放出仪式效果。
+totemic.page.performingCeremonies1=要执行一个&4仪式&0，必须注意几件事。要想选择并创建你的&4仪式&0，你必须在选择模式下向&1图腾柱&0演奏4种乐器，每个仪式乐器的演奏都有不同的顺序。要在选择模式下演奏多种乐器，只需要潜行并像往常一样演奏它们。当你演奏完4种与&4仪式&0相应的乐器后，仪式将开始执行创建。
+totemic.page.performingCeremonies2=当仪式处于执行创建状态时，&1图腾柱&0会接收附近的音乐并储存它们。这些音乐就叫做&4音乐旋律&0，它就是激活&4仪式&0所需的能量。当&4音乐旋律&0达到&4仪式&0所需旋律的阈值，仪式就执行完成并从图腾产生仪式效果。每个乐器有各自演奏的上限程度，所以执行任何仪式都不能只由一个乐器来演奏。
+totemic.page.performingCeremonies3=而且，你只有有限的时间维持仪式的进行，所以你需要尽快完成弹奏所有的乐器。当你弹奏了足够的&4音乐旋律&0，&4仪式&0将开始执行它的效果。有一些仪式只有瞬间的效果，而还有一些仪式则有持续的效果。
+totemic.page.performingCeremonies4=执行效果将会消耗&4音乐旋律&0。需要注意的是，效果仅会持续一段时间，时间结束后效果将停止。
 
 totemic.entry.rainDance=祈雨舞仪式
-totemic.page.rainDance0=&4祈雨舞仪式&0 可以为这个世界带来一场倾盆大雨. 如果你觉得雨太过于猛烈, &4干旱仪式&0 可以在任何时间执行, 它能够停止下雨. 但由于 &4祈雨舞仪式&0 带来的仪式效果十分强力, 所以可能会很难执行.
-totemic.page.rainDance1=&o就像牛蛙君一样&r.
+totemic.page.rainDance0=&4祈雨舞仪式&0可以为这个世界带来一场倾盆大雨。如果你觉得雨太过于猛烈，你可以在任何时间执行&4干旱仪式&0，使其停止下雨。但由于&4祈雨舞仪式&0带来的仪式效果十分强力，所以可能会很难执行。
+totemic.page.rainDance1=&o就像牛蛙君一样&r。
 
 totemic.entry.drought=干旱仪式
-totemic.page.drought0=
-totemic.page.drought1=&o是九尾鞭, 不是九喇嘛!&r
+totemic.page.drought0=&4干旱仪式&0将会终止所有的风暴，让天空放晴。其实这个仪式正好和&4祈雨舞仪式&0相反。
+totemic.page.drought1=&o是九尾鞭，不是九喇嘛!&r
 
 totemic.entry.warDance=战争仪式
-totemic.page.warDance0=&4战争仪式&0 是一种能让你认知即将到来的战争的仪式, 并激发你全身上下的肾上腺素. 当这个 &4仪式&0 执行完毕后执行者会在长时间内获得速度和力量的增益效果, 这样他们就能勇猛的冲进战场.
-totemic.page.warDance1=
+totemic.page.warDance0=&4战争仪式&0会激发人类原始的战争意识，你全身上下的肾上腺素。当这个&4仪式&0执行完毕后执行者会在长时间内获得速度和力量的增益效果，这样他们就能勇猛的冲进战场。
+totemic.page.warDance1=&o一盘很大的棋!&r
 
 totemic.entry.buffaloDance=曼丹野牛舞
+totemic.page.buffaloDance0=在白人践踏这片土地后，曾经遍布大平原的&1野牛&0也逐渐被屠杀殆尽。然而，他们还没有斩断最后一线希望：&4曼丹野牛舞&0仪式可以赋予附近的牛以力量，使他们成为真正的野牛。虽然这些获得新生的野牛的力量仍不及曾经的那些野牛，但随着时间的流逝，他们会成长起来的。
+totemic.page.buffaloDance1=&o别用红布&r
+
+totemic.entry.zaphkielWaltz=沙法尔圆舞
+totemic.page.zaphkielWaltz0=&4沙法尔圆舞&0是一种强力的生长仪式。仪式发动后，短时间内，附近的作物都会快速生长，同时鸡也会以更快的速度产卵。同时，这个仪式会把普通的树苗转化为&4红柏树苗&0。
+totemic.page.zaphkielWaltz1=&o哥特式的优雅&r
+
+totemic.entry.fluteInfusion=魔域长笛
+totemic.page.fluteInfusion0=&4魔域长笛&0可将有旋律的能量融入普通&1长笛&0中，籍此赋予长笛以特殊属性。不论是背包中的长笛，还是掉落在地上的长笛，都会受到此仪式的影响。
+totemic.page.fluteInfusion1=与普通长笛相比，&1蕴魔长笛&0的旋律更为特别，甚至能波及到&1动物&0和&1村民&0，同时也能对图腾造成一定影响。
+totemic.page.fluteInfusion2=&o比暮光杖更强！&r
+
+totemic.entry.baykokSummon=丧钟仪式
+totemic.page.baykokSummon0=&4丧钟仪式&0正是用于召唤名唤&4贝柯克&0的恶灵的仪式。谨记，发动此仪式前，务必保证万无一失。<br>&4贝柯克&0本身是一只化身为骷髅形态的恶灵，精通弓箭，用隐形的箭头无情地杀死所有与他为敌的人。在麻痹他的猎物后，他还会直接吞噬猎物的肝脏。
+totemic.page.baykokSummon1=若你成功击杀&4贝柯克&0，你便可以得到他使用的弓，以及其它各种战利品。这把弓可以射出能麻痹敌人的隐形箭(只有你能看到你发射出的箭)。与普通的弓相比，这把弓力量更强，也更容易附魔。
+totemic.page.baykokSummon2=&o你的末日到了&r
+
+totemic.entry.totemicStaff=图腾权杖
+totemic.page.totemicStaff0=图腾权杖可以告诉你一些方块的信息。<br>另外，左击图腾基座可以取消当前的仪式和音乐。
+totemic.page.totemicStaff1=&o不不不，这不是扳手&r
 
 totemic.entry.barkStripper=剥皮器
-totemic.page.barkStripper0=你可以通过 &1剥皮器&0 来从 &1红柏原木&0 上收集到树皮以及剥皮的红柏原木. 要使用它, 只需要拿着 &1剥皮器&0 右键一块红柏原木, 几秒后就可以完成剥皮. 你将会得到红柏树皮, 并且红柏原木也会变成剥皮的红柏原木.
-totemic.page.barkStripper1=红柏树皮和剥皮的红柏原木都有许多用途. &1剥皮的红柏原木&0 可以更高效率的合成木板, 或是把它放进熔炉里烧成木炭. 红柏树皮则可以合成许多方块和物品, 最常用的用途是用来加固物品.
+totemic.page.barkStripper0=你可以通过&1剥皮器&0来从&1红柏原木&0上收集到树皮以及剥皮的红柏原木。要使用它，只需要拿着&1剥皮器&0右键一块红柏原木，几秒后就可以完成剥皮。你将会得到红柏树皮，并且红柏原木也会变成剥皮的红柏原木。
+totemic.page.barkStripper1=红柏树皮和剥皮的红柏原木都有许多用途。&1剥皮的红柏原木&0可以合成更多的木板，或是把它放进熔炉里烧成木炭。红柏树皮则可以合成许多方块和物品，最常用的用途是用来加固物品。
+
+totemic.entry.baykokBow=贝柯克之弓
+totemic.page.baykokBow0=&4贝柯克之弓&0是一把无比强大的弓。它只可以通过斩杀恶灵&4贝柯克&0获得。贝柯克可以通过&4丧钟仪式&0生成。<br>这把弓发射的弓箭对他人是隐形的，而且能使目标迟缓并造成更大伤害。贝柯克之弓比普通的弓更耐久，也更容易获得好的附魔。
+
+totemic.entry.tipi=印第安帐篷
+totemic.page.tipi0=&1印第安帐篷&0有着圆锥体的外貌，属于帐篷的一种。由木质框架覆上野牛皮或棉布制成的帆布组成。在平整土地或草地上架起后，你可以直接睡在里面。
+totemic.page.tipi1=


### PR DESCRIPTION
The text rendering of totempedia page is pretty broken before the fix. It can't handle languages that rarely use spaces:
![1](https://cloud.githubusercontent.com/assets/5229241/16713390/9568cc92-46d8-11e6-9b09-c1c6866b9c19.jpg)

Vanilla `listFormattedStringToWidth` handles both line wraps and format, so why not?

@3TUSK @Learning-Intelligent-Distribution-Agent
