### PR TITLE
Config option: Reduce the number of totemists that spawn in a village.

### DIFF
--- a/src/main/java/pokefenn/totemic/configuration/ConfigGeneral.java
+++ b/src/main/java/pokefenn/totemic/configuration/ConfigGeneral.java
@@ -17,4 +17,8 @@ public class ConfigGeneral
     @RequiresMcRestart
     public boolean enableVillageMedicineWheel = true;
 
+    @Comment("Reduces the spawn chance of Medicine Man villagers")
+    @RequiresMcRestart
+    public boolean reduceMedicineManSpawnRate = false;
+
 }

--- a/src/main/java/pokefenn/totemic/init/ModVillagers.java
+++ b/src/main/java/pokefenn/totemic/init/ModVillagers.java
@@ -15,7 +15,11 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
 import pokefenn.totemic.Totemic;
+import pokefenn.totemic.configuration.ModConfig;
 import pokefenn.totemic.lib.Resources;
+import pokefenn.totemic.util.MiscUtil;
+
+import javax.annotation.Nullable;
 
 @EventBusSubscriber(modid = Totemic.MOD_ID)
 public final class ModVillagers
@@ -23,6 +27,20 @@ public final class ModVillagers
     public static final VillagerProfession profTotemist = new VillagerProfession(Resources.PREFIX_MOD + "totemist",
             Resources.PREFIX_MOD + "textures/entity/totemic_villager.png",
             "minecraft:textures/entity/zombie_villager/zombie_villager.png"); //TODO: Totemist zombie villager texture
+
+    @Nullable
+    public static VillagerProfession generateVillagerForPiece ()
+    {
+        if (ModConfig.general.reduceMedicineManSpawnRate) {
+            if (MiscUtil.random.nextBoolean()) {
+                return profTotemist;
+            } else {
+                return null;
+            }
+        } else {
+            return profTotemist;
+        }
+    }
 
     @SubscribeEvent
     public static void init(RegistryEvent.Register<VillagerProfession> event)

--- a/src/main/java/pokefenn/totemic/util/MiscUtil.java
+++ b/src/main/java/pokefenn/totemic/util/MiscUtil.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public class MiscUtil
 {
+    public static Random random = new Random();
+
     /**
      * Checks whether list1 is a prefix of list2, i.e.
      * the elements of list1 appear in order at the beginning of list2.

--- a/src/main/java/pokefenn/totemic/world/ComponentMedicineWheel.java
+++ b/src/main/java/pokefenn/totemic/world/ComponentMedicineWheel.java
@@ -21,6 +21,7 @@ import net.minecraft.world.gen.structure.StructureVillagePieces.PieceWeight;
 import net.minecraft.world.gen.structure.StructureVillagePieces.Start;
 import net.minecraft.world.gen.structure.StructureVillagePieces.Village;
 import net.minecraft.world.gen.structure.template.TemplateManager;
+import net.minecraftforge.fml.common.registry.VillagerRegistry;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.IVillageCreationHandler;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
 import pokefenn.totemic.api.TotemicRegistries;
@@ -31,8 +32,9 @@ import pokefenn.totemic.init.ModBlocks;
 import pokefenn.totemic.init.ModVillagers;
 import pokefenn.totemic.lib.WoodVariant;
 import pokefenn.totemic.tileentity.totem.TileTotemPole;
+import pokefenn.totemic.util.MiscUtil;
 
-public class ComponentMedicineWheel extends StructureVillagePieces.Village
+public class ComponentMedicineWheel extends ComponentTotemicPiece
 {
     private WoodVariant poleWood = WoodVariant.CEDAR;
 
@@ -175,12 +177,6 @@ public class ComponentMedicineWheel extends StructureVillagePieces.Village
 
         spawnVillagers(world, bb, 4, 1, 2,  1);
         return true;
-    }
-
-    @Override
-    protected VillagerProfession chooseForgeProfession(int count, VillagerProfession prof)
-    {
-        return ModVillagers.profTotemist;
     }
 
     @Override

--- a/src/main/java/pokefenn/totemic/world/ComponentTipi.java
+++ b/src/main/java/pokefenn/totemic/world/ComponentTipi.java
@@ -20,8 +20,9 @@ import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfessio
 import pokefenn.totemic.block.tipi.BlockTipi;
 import pokefenn.totemic.init.ModBlocks;
 import pokefenn.totemic.init.ModVillagers;
+import pokefenn.totemic.util.MiscUtil;
 
-public class ComponentTipi extends StructureVillagePieces.Village
+public class ComponentTipi extends ComponentTotemicPiece
 {
     public ComponentTipi()
     {
@@ -98,12 +99,6 @@ public class ComponentTipi extends StructureVillagePieces.Village
 
         //Place Tipi block itself
         setBlockState(world, ModBlocks.tipi.getDefaultState().withProperty(BlockTipi.FACING, dir), x, y, z, bb);
-    }
-
-    @Override
-    protected VillagerProfession chooseForgeProfession(int count, VillagerProfession prof)
-    {
-        return ModVillagers.profTotemist;
     }
 
     public static class CreationHandler implements IVillageCreationHandler

--- a/src/main/java/pokefenn/totemic/world/ComponentTotemicPiece.java
+++ b/src/main/java/pokefenn/totemic/world/ComponentTotemicPiece.java
@@ -1,0 +1,25 @@
+package pokefenn.totemic.world;
+
+import net.minecraft.world.gen.structure.StructureVillagePieces;
+import net.minecraftforge.fml.common.registry.VillagerRegistry;
+import pokefenn.totemic.init.ModVillagers;
+
+public abstract class ComponentTotemicPiece extends StructureVillagePieces.Village {
+    public ComponentTotemicPiece() {
+    }
+
+    public ComponentTotemicPiece(StructureVillagePieces.Start start, int type) {
+        super(start, type);
+    }
+
+    @Override
+    protected VillagerRegistry.VillagerProfession chooseForgeProfession(int count, VillagerRegistry.VillagerProfession prof) {
+        VillagerRegistry.VillagerProfession result = ModVillagers.generateVillagerForPiece();
+
+        if (result == null) {
+            return super.chooseForgeProfession(count, prof);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
While this unfortunately can result in a situation where no totemists
will spawn at all, it also mitigates circumstances where you can end up
with a village consisting almost entirely of totemists.

Each structure piece that spawns with a villager spawns a totemist, so
the more village structures (totems & tipii), the more totemists.
Additionally, totemist is a profession that can be randomly chosen.

My solution here was to, on a coinflip, return a totemist, or if that
fails, return the super to generate a random villager.

Additionally, as this is not necessarily something all players of the
mod would want (I just find that villagers on my modded server tend to
be flooded with medicine men), it's currently a configuration option
that defaults to false.