### PR TITLE
Add events to the Totemic API

### DIFF
--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.mojang.datafixers.util.Pair;
 
+import it.unimi.dsi.fastutil.ints.IntBooleanPair;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -60,7 +61,11 @@ public class TotemicEventHooks {
         return !NeoForge.EVENT_BUS.post(new TotemEffectEvent(level, pos, effect, repetition, context)).isCanceled();
     }
 
-    public boolean fireMedicineBagEffectEvent(MedicineBagEffect effect, TotemCarving carving, Player player, ItemStack medicineBag, int charge) {
-        return !NeoForge.EVENT_BUS.post(new MedicineBagEffectEvent(effect, carving, player, medicineBag, charge)).isCanceled();
+    /**
+     * @return a pair of the charge to deduct from the Medicine Bag and a boolean describing whether {@link MedicineBagEffect#medicineBagEffect} should be called.
+     */
+    public IntBooleanPair fireMedicineBagEffectEvent(MedicineBagEffect effect, TotemCarving carving, Player player, ItemStack medicineBag, int charge, int chargeToDeduct) {
+        var event = NeoForge.EVENT_BUS.post(new MedicineBagEffectEvent(effect, carving, player, medicineBag, charge, chargeToDeduct));
+        return IntBooleanPair.of(event.getChargeToDeduct(), !event.isCanceled());
     }
 }

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -1,0 +1,22 @@
+package pokefenn.totemic;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.neoforged.neoforge.common.NeoForge;
+import pokefenn.totemic.api.ceremony.Ceremony;
+import pokefenn.totemic.api.ceremony.CeremonyInstance;
+import pokefenn.totemic.api.ceremony.StartupContext;
+import pokefenn.totemic.api.event.CeremonyEvent;
+
+public class TotemicEventHooks {
+    //Make the hook methods in this class instance rather static methods, to facilitate future abstraction from NeoForge's event system
+    private static final TotemicEventHooks INSTANCE = new TotemicEventHooks();
+
+    public static TotemicEventHooks get() {
+        return INSTANCE;
+    }
+
+    public void fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+        NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupTick(level, pos, ceremony, instance, context));
+    }
+}

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -2,6 +2,8 @@ package pokefenn.totemic;
 
 import java.util.List;
 
+import com.mojang.datafixers.util.Pair;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.neoforged.neoforge.common.NeoForge;
@@ -20,9 +22,12 @@ public class TotemicEventHooks {
         return INSTANCE;
     }
 
-    public Ceremony fireCeremonySelection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, Ceremony ceremony) {
-        var event = new CeremonyEvent.Selection(level, pos, selectors, ceremony);
-        return NeoForge.EVENT_BUS.post(event).isCanceled() ? null : event.getCeremony();
+    /**
+     * @return a Pair of the Ceremony to be selected and a Boolean describing whether {@link CeremonyInstance#canSelect} should be called.
+     */
+    public Pair<Ceremony, Boolean> fireCeremonySelection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, Ceremony ceremony) {
+        var event = NeoForge.EVENT_BUS.post(new CeremonyEvent.Selection(level, pos, selectors, ceremony));
+        return Pair.of(event.getCeremony(), !event.isCanceled());
     }
 
     public boolean fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -5,6 +5,8 @@ import java.util.List;
 import com.mojang.datafixers.util.Pair;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.LevelAccessor;
 import net.neoforged.neoforge.common.NeoForge;
 import pokefenn.totemic.api.ceremony.Ceremony;
@@ -12,8 +14,11 @@ import pokefenn.totemic.api.ceremony.CeremonyEffectContext;
 import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.event.CeremonyEvent;
+import pokefenn.totemic.api.event.MedicineBagEffectEvent;
 import pokefenn.totemic.api.event.TotemEffectEvent;
 import pokefenn.totemic.api.music.MusicInstrument;
+import pokefenn.totemic.api.totem.MedicineBagEffect;
+import pokefenn.totemic.api.totem.TotemCarving;
 import pokefenn.totemic.api.totem.TotemEffect;
 import pokefenn.totemic.api.totem.TotemEffectContext;
 
@@ -53,5 +58,9 @@ public class TotemicEventHooks {
     //Totem Effect Events
     public boolean fireTotemEffectEvent(LevelAccessor level, BlockPos pos, TotemEffect effect, int repetition, TotemEffectContext context) {
         return !NeoForge.EVENT_BUS.post(new TotemEffectEvent(level, pos, effect, repetition, context)).isCanceled();
+    }
+
+    public boolean fireMedicineBagEffectEvent(MedicineBagEffect effect, TotemCarving carving, Player player, ItemStack medicineBag, int charge) {
+        return !NeoForge.EVENT_BUS.post(new MedicineBagEffectEvent(effect, carving, player, medicineBag, charge)).isCanceled();
     }
 }

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -25,8 +25,8 @@ public class TotemicEventHooks {
         return NeoForge.EVENT_BUS.post(event).isCanceled() ? null : event.getCeremony();
     }
 
-    public void fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
-        NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupTick(level, pos, ceremony, instance, context));
+    public boolean fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+        return !NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupTick(level, pos, ceremony, instance, context)).isCanceled();
     }
 
     public void fireCeremonyStartupFail(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -27,4 +27,8 @@ public class TotemicEventHooks {
     public void fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
         NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupTick(level, pos, ceremony, instance, context));
     }
+
+    public void fireCeremonyStartupFail(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+        NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupFail(level, pos, ceremony, instance, context));
+    }
 }

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -1,5 +1,7 @@
 package pokefenn.totemic;
 
+import java.util.List;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.neoforged.neoforge.common.NeoForge;
@@ -7,6 +9,7 @@ import pokefenn.totemic.api.ceremony.Ceremony;
 import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.event.CeremonyEvent;
+import pokefenn.totemic.api.music.MusicInstrument;
 
 public class TotemicEventHooks {
     //Make the hook methods in this class instance rather static methods, to facilitate future abstraction from NeoForge's event system
@@ -14,6 +17,11 @@ public class TotemicEventHooks {
 
     public static TotemicEventHooks get() {
         return INSTANCE;
+    }
+
+    public Ceremony fireCeremonySelection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, Ceremony ceremony) {
+        var event = new CeremonyEvent.Selection(level, pos, selectors, ceremony);
+        return NeoForge.EVENT_BUS.post(event).isCanceled() ? null : event.getCeremony();
     }
 
     public void fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -2,9 +2,8 @@ package pokefenn.totemic;
 
 import java.util.List;
 
-import com.mojang.datafixers.util.Pair;
-
 import it.unimi.dsi.fastutil.ints.IntBooleanPair;
+import it.unimi.dsi.fastutil.objects.ObjectBooleanPair;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -24,7 +23,8 @@ import pokefenn.totemic.api.totem.TotemEffect;
 import pokefenn.totemic.api.totem.TotemEffectContext;
 
 public class TotemicEventHooks {
-    //Make the hook methods in this class instance rather static methods, to facilitate future abstraction from NeoForge's event system
+    //Make the hook methods in this class instance rather static methods, to facilitate future abstraction from NeoForge's event system.
+    //For the same reason, we return pairs rather than event instances from methods.
     private static final TotemicEventHooks INSTANCE = new TotemicEventHooks();
 
     public static TotemicEventHooks get() {
@@ -33,11 +33,11 @@ public class TotemicEventHooks {
 
     //Ceremony Events
     /**
-     * @return a Pair of the Ceremony to be selected and a Boolean describing whether {@link CeremonyInstance#canSelect} should be called.
+     * @return a Pair of the Ceremony to be selected and a boolean describing whether the call to {@link CeremonyInstance#canSelect} should be skipped.
      */
-    public Pair<Ceremony, Boolean> fireCeremonySelection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, Ceremony ceremony) {
+    public ObjectBooleanPair<Ceremony> fireCeremonySelection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, Ceremony ceremony) {
         var event = NeoForge.EVENT_BUS.post(new CeremonyEvent.Selection(level, pos, selectors, ceremony));
-        return Pair.of(event.getCeremony(), !event.isCanceled());
+        return ObjectBooleanPair.of(event.getCeremony(), event.getSkipSelectionCheck());
     }
 
     public boolean fireCeremonyStartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -12,7 +12,10 @@ import pokefenn.totemic.api.ceremony.CeremonyEffectContext;
 import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.event.CeremonyEvent;
+import pokefenn.totemic.api.event.TotemEffectEvent;
 import pokefenn.totemic.api.music.MusicInstrument;
+import pokefenn.totemic.api.totem.TotemEffect;
+import pokefenn.totemic.api.totem.TotemEffectContext;
 
 public class TotemicEventHooks {
     //Make the hook methods in this class instance rather static methods, to facilitate future abstraction from NeoForge's event system
@@ -22,6 +25,7 @@ public class TotemicEventHooks {
         return INSTANCE;
     }
 
+    //Ceremony Events
     /**
      * @return a Pair of the Ceremony to be selected and a Boolean describing whether {@link CeremonyInstance#canSelect} should be called.
      */
@@ -44,5 +48,10 @@ public class TotemicEventHooks {
 
     public boolean fireCeremonyEffectTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, CeremonyEffectContext context) {
         return !NeoForge.EVENT_BUS.post(new CeremonyEvent.EffectTick(level, pos, ceremony, instance, context)).isCanceled();
+    }
+
+    //Totem Effect Events
+    public boolean fireTotemEffectEvent(LevelAccessor level, BlockPos pos, TotemEffect effect, int repetition, TotemEffectContext context) {
+        return !NeoForge.EVENT_BUS.post(new TotemEffectEvent(level, pos, effect, repetition, context)).isCanceled();
     }
 }

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -6,6 +6,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.neoforged.neoforge.common.NeoForge;
 import pokefenn.totemic.api.ceremony.Ceremony;
+import pokefenn.totemic.api.ceremony.CeremonyEffectContext;
 import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.event.CeremonyEvent;
@@ -34,5 +35,9 @@ public class TotemicEventHooks {
 
     public boolean fireCeremonyStartupSuccess(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
         return !NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupSuccess(level, pos, ceremony, instance, context)).isCanceled();
+    }
+
+    public boolean fireCeremonyEffectTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, CeremonyEffectContext context) {
+        return !NeoForge.EVENT_BUS.post(new CeremonyEvent.EffectTick(level, pos, ceremony, instance, context)).isCanceled();
     }
 }

--- a/src/main/java/pokefenn/totemic/TotemicEventHooks.java
+++ b/src/main/java/pokefenn/totemic/TotemicEventHooks.java
@@ -31,4 +31,8 @@ public class TotemicEventHooks {
     public void fireCeremonyStartupFail(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
         NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupFail(level, pos, ceremony, instance, context));
     }
+
+    public boolean fireCeremonyStartupSuccess(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+        return !NeoForge.EVENT_BUS.post(new CeremonyEvent.StartupSuccess(level, pos, ceremony, instance, context)).isCanceled();
+    }
 }

--- a/src/main/java/pokefenn/totemic/api/ceremony/CeremonyInstance.java
+++ b/src/main/java/pokefenn/totemic/api/ceremony/CeremonyInstance.java
@@ -62,7 +62,7 @@ public interface CeremonyInstance extends INBTSerializable<Tag> { //TODO: Consid
 
     /**
      * Called when the player has successfully finished the startup and before the ceremony effect begins. If {@code false} is returned,
-     * the startup will be considered failed and the effect is not started.
+     * the startup will be considered failed and the effect is not started (however, this behavior will probably change in the future).
      * <p>
      * Note that this method is bypassed if the player uses the Creative Ceremony Cheat item.
      * <p>

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -14,6 +14,9 @@ import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.music.MusicInstrument;
 
+/**
+ * Various events that are fired during different parts of a Ceremony
+ */
 public abstract class CeremonyEvent extends Event {
     private final LevelAccessor level;
     private final BlockPos pos;
@@ -59,9 +62,10 @@ public abstract class CeremonyEvent extends Event {
      * This event is fired when the required number of instruments for selecting a Ceremony has been played,
      * even when the instruments don't match any Ceremony.
      * <p>
-     * If this event is canceled, no Ceremony will be selected.
+     * If this event is canceled, no Ceremony will be selected. This event is only fired on the server side.
      */
     public static class Selection extends Event implements ICancellableEvent {
+        //not a subclass of CeremonyEvent since this is the only one where Ceremony is mutable and there's no CeremonyInstance
         private final LevelAccessor level;
         private final BlockPos pos;
         private final List<MusicInstrument> selectors;
@@ -121,6 +125,27 @@ public abstract class CeremonyEvent extends Event {
         private final StartupContext context;
 
         public StartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+            super(level, pos, ceremony, instance);
+            this.context = context;
+        }
+
+        /**
+         * @return a StartupContext providing details about the Ceremony's progress and allowing control over the Ceremony
+         */
+        public StartupContext getContext() {
+            return context;
+        }
+    }
+
+    /**
+     * This event is fired when the player was not successful in completing the ceremony startup because the time ran out.
+     * <p>
+     * This event is only fired on the server side.
+     */
+    public static class StartupFail extends CeremonyEvent {
+        private final StartupContext context;
+
+        public StartupFail(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
             super(level, pos, ceremony, instance);
             this.context = context;
         }

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -62,6 +62,7 @@ public abstract class CeremonyEvent extends Event {
     /**
      * This event is fired when the required number of instruments for selecting a Ceremony has been played,
      * even when the instruments don't match any Ceremony.
+     * It allows changing the Ceremony that will be selected.
      * <p>
      * When canceled, the Ceremony's own check of whether it can be selected (e.g. the Buffalo Dance checking whether
      * cows are nearby) will be skipped. If you want to prevent selecting a Ceremony, use {@code setCeremony(null)}

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -1,0 +1,71 @@
+package pokefenn.totemic.api.event;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.neoforged.bus.api.Event;
+import pokefenn.totemic.api.ceremony.Ceremony;
+import pokefenn.totemic.api.ceremony.CeremonyInstance;
+import pokefenn.totemic.api.ceremony.StartupContext;
+
+public abstract class CeremonyEvent extends Event {
+    private final LevelAccessor level;
+    private final BlockPos pos;
+    private final Ceremony ceremony;
+    private final CeremonyInstance instance;
+
+    public CeremonyEvent(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance) {
+        this.level = level;
+        this.pos = pos;
+        this.ceremony = ceremony;
+        this.instance = instance;
+    }
+
+    /**
+     * @return the level where the Ceremony is performed
+     */
+    public LevelAccessor getLevel() {
+        return level;
+    }
+
+    /**
+     * @return the position of the Totem Base where the Ceremony is performed
+     */
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    /**
+     * @return the Ceremony that is being performed
+     */
+    public Ceremony getCeremony() {
+        return ceremony;
+    }
+
+    /**
+     * @return the CeremonyInstance of the performed Ceremony
+     */
+    public CeremonyInstance getCeremonyInstance() {
+        return instance;
+    }
+
+    /**
+     * This event is fired every tick during the Ceremony startup phase.
+     * <p>
+     * This event is not cancellable, but the startup phase can be cancelled or skipped using the {@link #getContext()} method.
+     */
+    public static class StartupTick extends CeremonyEvent {
+        private final StartupContext context;
+
+        public StartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+            super(level, pos, ceremony, instance);
+            this.context = context;
+        }
+
+        /**
+         * @return a StartupContext providing details about the Ceremony's progress and allowing control over the Ceremony
+         */
+        public StartupContext getContext() {
+            return context;
+        }
+    }
+}

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -157,4 +157,26 @@ public abstract class CeremonyEvent extends Event {
             return context;
         }
     }
+
+    /**
+     * This event is fired when the player has successfully completed the ceremony startup.
+     * <p>
+     * When this event is cancelled, the Ceremony is considered failed and the effect is not started (however, this behavior will probably change in the future).
+     * This event is only fired on the server side, and it will not fire when the player uses the Creative Ceremony Cheat item.
+     */
+    public static class StartupSuccess extends CeremonyEvent implements ICancellableEvent {
+        private final StartupContext context;
+
+        public StartupSuccess(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
+            super(level, pos, ceremony, instance);
+            this.context = context;
+        }
+
+        /**
+         * @return a StartupContext providing details about the Ceremony's progress and allowing control over the Ceremony
+         */
+        public StartupContext getContext() {
+            return context;
+        }
+    }
 }

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -64,7 +64,8 @@ public abstract class CeremonyEvent extends Event {
      * even when the instruments don't match any Ceremony.
      * <p>
      * When canceled, the Ceremony's own check of whether it can be selected (e.g. the Buffalo Dance checking whether
-     * cows are nearby) will be skipped.
+     * cows are nearby) will be skipped. If you want to prevent selecting a Ceremony, use {@code setCeremony(null)}
+     * instead.
      */
     public static class Selection extends Event implements ICancellableEvent {
         //not a subclass of CeremonyEvent since this is the only one where Ceremony is mutable and there's no CeremonyInstance
@@ -164,7 +165,7 @@ public abstract class CeremonyEvent extends Event {
     /**
      * This event is fired when the player has successfully completed the ceremony startup.
      * <p>
-     * When cancelled, the Ceremony is considered failed and the effect is not started (however, this behavior will probably change in the future).
+     * When canceled, the Ceremony is considered failed and the effect is not started (however, this behavior will probably change in the future).
      * This event is only fired on the server side, and it will not fire when the player uses the Creative Ceremony Cheat item.
      */
     public static class StartupSuccess extends CeremonyEvent implements ICancellableEvent {
@@ -187,7 +188,7 @@ public abstract class CeremonyEvent extends Event {
      * This event is fired every tick during the Ceremony effect phase. Will only be fired once if the Ceremony effect is instantaneous
      * (i.e. {@link CeremonyInstance#getEffectTime()} == 0).
      * <p>
-     * When cancelled, {@link CeremonyInstance#effect} will not be called.
+     * When canceled, {@link CeremonyInstance#effect} will not be called.
      */
     public static class EffectTick extends CeremonyEvent implements ICancellableEvent {
         private final CeremonyEffectContext context;

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -1,11 +1,18 @@
 package pokefenn.totemic.api.event;
 
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
 import pokefenn.totemic.api.ceremony.Ceremony;
 import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
+import pokefenn.totemic.api.music.MusicInstrument;
 
 public abstract class CeremonyEvent extends Event {
     private final LevelAccessor level;
@@ -46,6 +53,63 @@ public abstract class CeremonyEvent extends Event {
      */
     public CeremonyInstance getCeremonyInstance() {
         return instance;
+    }
+
+    /**
+     * This event is fired when the required number of instruments for selecting a Ceremony has been played,
+     * even when the instruments don't match any Ceremony.
+     * <p>
+     * If this event is canceled, no Ceremony will be selected.
+     */
+    public static class Selection extends Event implements ICancellableEvent {
+        private final LevelAccessor level;
+        private final BlockPos pos;
+        private final List<MusicInstrument> selectors;
+        private @Nullable Ceremony ceremony;
+
+        public Selection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, @Nullable Ceremony ceremony) {
+            this.level = level;
+            this.pos = pos;
+            this.selectors = selectors;
+            this.ceremony = ceremony;
+        }
+
+        /**
+         * @return the level where the Ceremony is performed
+         */
+        public LevelAccessor getLevel() {
+            return level;
+        }
+
+        /**
+         * @return the position of the Totem Base where the Ceremony is performed
+         */
+        public BlockPos getPos() {
+            return pos;
+        }
+
+        /**
+         * @return the list of selecting instruments
+         */
+        public List<MusicInstrument> getSelectors() {
+            return Collections.unmodifiableList(selectors);
+        }
+
+        /**
+         * Returns the Ceremony that is about to be selected. May be null if the selecting instruments don't match any
+         * Ceremony, or if the value was modified using {@link #setCeremony(Ceremony)}.
+         */
+        @Nullable
+        public Ceremony getCeremony() {
+            return ceremony;
+        }
+
+        /**
+         * Modifies the Ceremony that will be selected.
+         */
+        public void setCeremony(@Nullable Ceremony ceremony) {
+            this.ceremony = ceremony;
+        }
     }
 
     /**

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.LevelAccessor;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import pokefenn.totemic.api.ceremony.Ceremony;
+import pokefenn.totemic.api.ceremony.CeremonyEffectContext;
 import pokefenn.totemic.api.ceremony.CeremonyInstance;
 import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.music.MusicInstrument;
@@ -176,6 +177,28 @@ public abstract class CeremonyEvent extends Event {
          * @return a StartupContext providing details about the Ceremony's progress and allowing control over the Ceremony
          */
         public StartupContext getContext() {
+            return context;
+        }
+    }
+
+    /**
+     * This event is fired every tick during the Ceremony effect phase. Will only be fired once if the Ceremony effect is instantaneous
+     * (i.e. {@link CeremonyInstance#getEffectTime()} == 0).
+     * <p>
+     * When this event is cancelled, {@link CeremonyInstance#effect} will not be called.
+     */
+    public static class EffectTick extends CeremonyEvent implements ICancellableEvent {
+        private final CeremonyEffectContext context;
+
+        public EffectTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, CeremonyEffectContext context) {
+            super(level, pos, ceremony, instance);
+            this.context = context;
+        }
+
+        /**
+         * @return a CeremonyEffectContext providing details about the Ceremony's progress and allowing control over the Ceremony
+         */
+        public CeremonyEffectContext getContext() {
             return context;
         }
     }

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -62,18 +62,16 @@ public abstract class CeremonyEvent extends Event {
     /**
      * This event is fired when the required number of instruments for selecting a Ceremony has been played,
      * even when the instruments don't match any Ceremony.
-     * It allows changing the Ceremony that will be selected.
-     * <p>
-     * When canceled, the Ceremony's own check of whether it can be selected (e.g. the Buffalo Dance checking whether
-     * cows are nearby) will be skipped. If you want to prevent selecting a Ceremony, use {@code setCeremony(null)}
-     * instead.
+     * It allows changing the Ceremony that will be selected (if any), and skipping the Ceremony's selection check.
      */
-    public static class Selection extends Event implements ICancellableEvent {
+    public static class Selection extends Event {
         //not a subclass of CeremonyEvent since this is the only one where Ceremony is mutable and there's no CeremonyInstance
         private final LevelAccessor level;
         private final BlockPos pos;
         private final List<MusicInstrument> selectors;
+
         private @Nullable Ceremony ceremony;
+        private boolean skipSelectionCheck = false;
 
         public Selection(LevelAccessor level, BlockPos pos, List<MusicInstrument> selectors, @Nullable Ceremony ceremony) {
             this.level = level;
@@ -113,10 +111,25 @@ public abstract class CeremonyEvent extends Event {
         }
 
         /**
-         * Modifies the Ceremony that will be selected, if any.
+         * Modifies the Ceremony that will be selected. Pass null to select no Ceremony.
          */
         public void setCeremony(@Nullable Ceremony ceremony) {
             this.ceremony = ceremony;
+        }
+
+        /**
+         * If this method returns true, the Ceremony's selection check (e.g. the Buffalo Dance checking for cows)
+         * will be skipped.
+         */
+        public boolean getSkipSelectionCheck() {
+            return skipSelectionCheck;
+        }
+
+        /**
+         * When set to true, the Ceremony's selection check (e.g. the Buffalo Dance checking for cows) will be skipped.
+         */
+        public void setSkipSelectionCheck(boolean skipSelectionCheck) {
+            this.skipSelectionCheck = skipSelectionCheck;
         }
     }
 

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -63,7 +63,8 @@ public abstract class CeremonyEvent extends Event {
      * This event is fired when the required number of instruments for selecting a Ceremony has been played,
      * even when the instruments don't match any Ceremony.
      * <p>
-     * If canceled, no Ceremony will be selected. This event is only fired on the server side.
+     * When canceled, the Ceremony's own check of whether it can be selected (e.g. the Buffalo Dance checking whether
+     * cows are nearby) will be skipped.
      */
     public static class Selection extends Event implements ICancellableEvent {
         //not a subclass of CeremonyEvent since this is the only one where Ceremony is mutable and there's no CeremonyInstance
@@ -110,7 +111,7 @@ public abstract class CeremonyEvent extends Event {
         }
 
         /**
-         * Modifies the Ceremony that will be selected.
+         * Modifies the Ceremony that will be selected, if any.
          */
         public void setCeremony(@Nullable Ceremony ceremony) {
             this.ceremony = ceremony;

--- a/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/CeremonyEvent.java
@@ -16,7 +16,7 @@ import pokefenn.totemic.api.ceremony.StartupContext;
 import pokefenn.totemic.api.music.MusicInstrument;
 
 /**
- * Various events that are fired during different parts of a Ceremony
+ * Various events that are fired during different parts of a Ceremony.
  */
 public abstract class CeremonyEvent extends Event {
     private final LevelAccessor level;
@@ -63,7 +63,7 @@ public abstract class CeremonyEvent extends Event {
      * This event is fired when the required number of instruments for selecting a Ceremony has been played,
      * even when the instruments don't match any Ceremony.
      * <p>
-     * If this event is canceled, no Ceremony will be selected. This event is only fired on the server side.
+     * If canceled, no Ceremony will be selected. This event is only fired on the server side.
      */
     public static class Selection extends Event implements ICancellableEvent {
         //not a subclass of CeremonyEvent since this is the only one where Ceremony is mutable and there's no CeremonyInstance
@@ -120,9 +120,10 @@ public abstract class CeremonyEvent extends Event {
     /**
      * This event is fired every tick during the Ceremony startup phase.
      * <p>
-     * This event is not cancellable, but the startup phase can be cancelled or skipped using the {@link #getContext()} method.
+     * When canceled, side effects of the startup (e.g. the damage dealt by the Sun Dance) will not be applied.
+     * The startup phase can be skipped or aborted entirely by using {@link #getContext()}.
      */
-    public static class StartupTick extends CeremonyEvent {
+    public static class StartupTick extends CeremonyEvent implements ICancellableEvent {
         private final StartupContext context;
 
         public StartupTick(LevelAccessor level, BlockPos pos, Ceremony ceremony, CeremonyInstance instance, StartupContext context) {
@@ -162,7 +163,7 @@ public abstract class CeremonyEvent extends Event {
     /**
      * This event is fired when the player has successfully completed the ceremony startup.
      * <p>
-     * When this event is cancelled, the Ceremony is considered failed and the effect is not started (however, this behavior will probably change in the future).
+     * When cancelled, the Ceremony is considered failed and the effect is not started (however, this behavior will probably change in the future).
      * This event is only fired on the server side, and it will not fire when the player uses the Creative Ceremony Cheat item.
      */
     public static class StartupSuccess extends CeremonyEvent implements ICancellableEvent {
@@ -185,7 +186,7 @@ public abstract class CeremonyEvent extends Event {
      * This event is fired every tick during the Ceremony effect phase. Will only be fired once if the Ceremony effect is instantaneous
      * (i.e. {@link CeremonyInstance#getEffectTime()} == 0).
      * <p>
-     * When this event is cancelled, {@link CeremonyInstance#effect} will not be called.
+     * When cancelled, {@link CeremonyInstance#effect} will not be called.
      */
     public static class EffectTick extends CeremonyEvent implements ICancellableEvent {
         private final CeremonyEffectContext context;

--- a/src/main/java/pokefenn/totemic/api/event/MedicineBagEffectEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/MedicineBagEffectEvent.java
@@ -11,7 +11,8 @@ import pokefenn.totemic.api.totem.TotemCarving;
 /**
  * This event is fired every time a {@link MedicineBagEffect} is applied.
  * <p>
- * When canceled, {@link MedicineBagEffect#medicineBagEffect} will not be called.
+ * When canceled, {@link MedicineBagEffect#medicineBagEffect} will not be called, but charge will still be drained from
+ * the Medicine Bag.
  * <p>
  * Note: This event is currently fired multiple times if a {@link PortableTotemCarving} contains multiple
  * MedicineBagEffects (like the Cow and Ocelot carvings), and not fired at all for PortableTotemCarvings with no
@@ -25,13 +26,15 @@ public class MedicineBagEffectEvent extends Event implements ICancellableEvent {
     private final Player player;
     private final ItemStack medicineBag;
     private final int charge;
+    private int chargeToDeduct;
 
-    public MedicineBagEffectEvent(MedicineBagEffect effect, TotemCarving carving, Player player, ItemStack medicineBag, int charge) {
+    public MedicineBagEffectEvent(MedicineBagEffect effect, TotemCarving carving, Player player, ItemStack medicineBag, int charge, int chargeToDeduct) {
         this.effect = effect;
         this.carving = carving;
         this.player = player;
         this.medicineBag = medicineBag;
         this.charge = charge;
+        this.chargeToDeduct = chargeToDeduct;
     }
 
     /**
@@ -67,5 +70,27 @@ public class MedicineBagEffectEvent extends Event implements ICancellableEvent {
      */
     public int getCharge() {
         return charge;
+    }
+
+    /**
+     * @return how much charge to deduct from the Medicine Bag. By default, this is equal to {@code getEffect().getInterval()}.
+     */
+    public int getChargeToDeduct() {
+        return chargeToDeduct;
+    }
+
+    /**
+     * Modifies how much charge will be deducted from the Medicine Bag.
+     * Will be ignored for Creative Medicine Bags.
+     */
+    public void setChargeToDeduct(int chargeToDeduct) {
+        this.chargeToDeduct = chargeToDeduct;
+    }
+
+    /**
+     * @return true if the item is a Creative Medicine Bag as opposed to a regular Medicine Bag
+     */
+    public boolean isCreativeMedicineBag() {
+        return charge == -1;
     }
 }

--- a/src/main/java/pokefenn/totemic/api/event/MedicineBagEffectEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/MedicineBagEffectEvent.java
@@ -1,0 +1,71 @@
+package pokefenn.totemic.api.event;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import pokefenn.totemic.api.totem.MedicineBagEffect;
+import pokefenn.totemic.api.totem.PortableTotemCarving;
+import pokefenn.totemic.api.totem.TotemCarving;
+
+/**
+ * This event is fired every time a {@link MedicineBagEffect} is applied.
+ * <p>
+ * When canceled, {@link MedicineBagEffect#medicineBagEffect} will not be called.
+ * <p>
+ * Note: This event is currently fired multiple times if a {@link PortableTotemCarving} contains multiple
+ * MedicineBagEffects (like the Cow and Ocelot carvings), and not fired at all for PortableTotemCarvings with no
+ * effects (like the 'none' carving). This is expected to change in the future.
+ *
+ * @see TotemEffectEvent
+ */
+public class MedicineBagEffectEvent extends Event implements ICancellableEvent {
+    private final MedicineBagEffect effect;
+    private final TotemCarving carving;
+    private final Player player;
+    private final ItemStack medicineBag;
+    private final int charge;
+
+    public MedicineBagEffectEvent(MedicineBagEffect effect, TotemCarving carving, Player player, ItemStack medicineBag, int charge) {
+        this.effect = effect;
+        this.carving = carving;
+        this.player = player;
+        this.medicineBag = medicineBag;
+        this.charge = charge;
+    }
+
+    /**
+     * @return the MedicineBagEffect that is being applied
+     */
+    public MedicineBagEffect getEffect() {
+        return effect;
+    }
+
+    /**
+     * @return the TotemCarving that the effect belongs to
+     */
+    public TotemCarving getCarving() {
+        return carving;
+    }
+
+    /**
+     * @return the player the effect is applied to
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * @return the Medicine Bag item stack the effect originates from
+     */
+    public ItemStack getMedicineBag() {
+        return medicineBag;
+    }
+
+    /**
+     * @return the Medicine Bag's charge before the application of the effect, or -1 if it is a Creative Medicine Bag
+     */
+    public int getCharge() {
+        return charge;
+    }
+}

--- a/src/main/java/pokefenn/totemic/api/event/MedicineBagEffectEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/MedicineBagEffectEvent.java
@@ -13,6 +13,7 @@ import pokefenn.totemic.api.totem.TotemCarving;
  * <p>
  * When canceled, {@link MedicineBagEffect#medicineBagEffect} will not be called, but charge will still be drained from
  * the Medicine Bag.
+ * The amount of charge to be drained can be modified.
  * <p>
  * Note: This event is currently fired multiple times if a {@link PortableTotemCarving} contains multiple
  * MedicineBagEffects (like the Cow and Ocelot carvings), and not fired at all for PortableTotemCarvings with no

--- a/src/main/java/pokefenn/totemic/api/event/TotemEffectEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/TotemEffectEvent.java
@@ -1,0 +1,77 @@
+package pokefenn.totemic.api.event;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import pokefenn.totemic.api.TotemicAPI;
+import pokefenn.totemic.api.totem.TotemCarving;
+import pokefenn.totemic.api.totem.TotemEffect;
+import pokefenn.totemic.api.totem.TotemEffectContext;
+
+/**
+ * This event is fired when a Totem Effect is applied at a Totem Base.
+ * <p>
+ * When canceled, {@link TotemEffect#effect} will not be called.
+ */
+public class TotemEffectEvent extends Event implements ICancellableEvent {
+    private final LevelAccessor level;
+    private final BlockPos pos;
+    private final TotemEffect effect;
+    private final int repetition;
+    private final TotemEffectContext context;
+
+    public TotemEffectEvent(LevelAccessor level, BlockPos pos, TotemEffect effect, int repetition, TotemEffectContext context) {
+        this.level = level;
+        this.pos = pos;
+        this.effect = effect;
+        this.repetition = repetition;
+        this.context = context;
+    }
+
+    /**
+     * @return the level where the TotemEffect is applied
+     */
+    public LevelAccessor getLevel() {
+        return level;
+    }
+
+    /**
+     * @return the position of the Totem Base where the effect is applied
+     */
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    /**
+     * @return the TotemEffect that is being applied
+     */
+    public TotemEffect getEffect() {
+        return effect;
+    }
+
+    /**
+     * @return the TotemCarving that the effect belongs to
+     */
+    public TotemCarving getCarving() {
+        //TODO: We currently don't store which TotemCarving each TotemEffect comes from, necessitating an expensive search
+        return TotemicAPI.get().registry().totemCarvings().stream()
+                .filter(carving -> carving.getEffects().contains(effect))
+                .findAny()
+                .orElseThrow();
+    }
+
+    /**
+     * @return the number of times the TotemCarving is repeated on the Totem Pole
+     */
+    public int getRepetition() {
+        return repetition;
+    }
+
+    /**
+     * @return a TotemEffectContext providing details about the Totem Pole the effect originates from
+     */
+    public TotemEffectContext getContext() {
+        return context;
+    }
+}

--- a/src/main/java/pokefenn/totemic/api/event/TotemEffectEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/TotemEffectEvent.java
@@ -13,6 +13,9 @@ import pokefenn.totemic.api.totem.TotemEffectContext;
  * This event is fired when a Totem Effect is applied at a Totem Base.
  * <p>
  * When canceled, {@link TotemEffect#effect} will not be called.
+ * <p>
+ * Note: This event is currently fired multiple times if a TotemCarving contains multiple TotemEffects (like the Cow and Ocelot carvings),
+ * and not fired at all for TotemCarvings with no effects (like the 'none' carving). This is expected to change in the future.
  */
 public class TotemEffectEvent extends Event implements ICancellableEvent {
     private final LevelAccessor level;
@@ -54,11 +57,7 @@ public class TotemEffectEvent extends Event implements ICancellableEvent {
      * @return the TotemCarving that the effect belongs to
      */
     public TotemCarving getCarving() {
-        //TODO: We currently don't store which TotemCarving each TotemEffect comes from, necessitating an expensive search
-        return TotemicAPI.get().registry().totemCarvings().stream()
-                .filter(carving -> carving.getEffects().contains(effect))
-                .findAny()
-                .orElseThrow();
+        return TotemicAPI.get().totemEffect().getCarvingForEffect(effect);
     }
 
     /**

--- a/src/main/java/pokefenn/totemic/api/event/TotemEffectEvent.java
+++ b/src/main/java/pokefenn/totemic/api/event/TotemEffectEvent.java
@@ -10,12 +10,15 @@ import pokefenn.totemic.api.totem.TotemEffect;
 import pokefenn.totemic.api.totem.TotemEffectContext;
 
 /**
- * This event is fired when a Totem Effect is applied at a Totem Base.
+ * This event is fired every time a {@link TotemEffect} is applied at a Totem Base.
  * <p>
  * When canceled, {@link TotemEffect#effect} will not be called.
  * <p>
- * Note: This event is currently fired multiple times if a TotemCarving contains multiple TotemEffects (like the Cow and Ocelot carvings),
- * and not fired at all for TotemCarvings with no effects (like the 'none' carving). This is expected to change in the future.
+ * Note: This event is currently fired multiple times if a {@link TotemCarving} contains multiple TotemEffects (like
+ * the Cow and Ocelot carvings), and not fired at all for TotemCarvings with no effects (like the 'none' carving).
+ * This is expected to change in the future.
+ *
+ * @see MedicineBagEffectEvent
  */
 public class TotemEffectEvent extends Event implements ICancellableEvent {
     private final LevelAccessor level;

--- a/src/main/java/pokefenn/totemic/api/totem/TotemCarving.java
+++ b/src/main/java/pokefenn/totemic/api/totem/TotemCarving.java
@@ -18,6 +18,8 @@ import pokefenn.totemic.api.registry.RegistryAPI;
 
 /**
  * Represents a Totem Pole carving. A TotemCarving consists of one or more {@link TotemEffect}s.
+ *
+ * @see PortableTotemCarving
  */
 public sealed class TotemCarving permits PortableTotemCarving {
     public static final Codec<TotemCarving> CODEC = TotemicAPI.get().registry().totemCarvings().byNameCodec();

--- a/src/main/java/pokefenn/totemic/api/totem/TotemEffect.java
+++ b/src/main/java/pokefenn/totemic/api/totem/TotemEffect.java
@@ -4,7 +4,9 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 
 /**
- * A single effect of a TotemCarving.
+ * A single effect of a {@link TotemCarving}.
+ *
+ * @see MedicineBagEffect
  */
 public abstract class TotemEffect {
     /**

--- a/src/main/java/pokefenn/totemic/api/totem/TotemEffectAPI.java
+++ b/src/main/java/pokefenn/totemic/api/totem/TotemEffectAPI.java
@@ -25,4 +25,9 @@ public interface TotemEffectAPI {
      * more consistent with Totemic's effects.
      */
     int getDefaultRange(int repetition, TotemEffectContext context);
+
+    /**
+     * Returns the TotemCarving the specified TotemEffect belongs to.
+     */
+    TotemCarving getCarvingForEffect(TotemEffect effect);
 }

--- a/src/main/java/pokefenn/totemic/apiimpl/totem/TotemEffectApiImpl.java
+++ b/src/main/java/pokefenn/totemic/apiimpl/totem/TotemEffectApiImpl.java
@@ -1,5 +1,12 @@
 package pokefenn.totemic.apiimpl.totem;
 
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import pokefenn.totemic.api.TotemicAPI;
+import pokefenn.totemic.api.totem.TotemCarving;
+import pokefenn.totemic.api.totem.TotemEffect;
 import pokefenn.totemic.api.totem.TotemEffectAPI;
 import pokefenn.totemic.api.totem.TotemEffectContext;
 
@@ -11,5 +18,23 @@ public enum TotemEffectApiImpl implements TotemEffectAPI {
         final int baseRange = 5;
         final int musicStep = TotemEffectAPI.MAX_TOTEM_EFFECT_MUSIC / 4;
         return baseRange + context.getTotemEffectMusic() / musicStep + (context.getPoleSize() == TotemEffectAPI.MAX_POLE_SIZE ? 1 : 0);
+    }
+
+    //Computed lazily
+    private static Map<TotemEffect, TotemCarving> effectToCarvingMap = null;
+
+    @Override
+    public TotemCarving getCarvingForEffect(TotemEffect effect) {
+        var localEffectToCarvingMap = effectToCarvingMap; //local variable for thread safety
+        if(localEffectToCarvingMap == null) {
+            var builder = ImmutableMap.<TotemEffect, TotemCarving>builder();
+            for(var carving : TotemicAPI.get().registry().totemCarvings()) {
+                for(var eff : carving.getEffects())
+                    builder.put(eff, carving);
+            }
+            effectToCarvingMap = localEffectToCarvingMap = builder.build();
+        }
+
+        return localEffectToCarvingMap.get(effect);
     }
 }

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateCeremonyEffect.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateCeremonyEffect.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import pokefenn.totemic.Totemic;
+import pokefenn.totemic.TotemicEventHooks;
 import pokefenn.totemic.api.TotemicAPI;
 import pokefenn.totemic.api.ceremony.Ceremony;
 import pokefenn.totemic.api.ceremony.CeremonyEffectContext;
@@ -58,7 +59,8 @@ public final class StateCeremonyEffect extends TotemState implements CeremonyEff
         Level world = tile.getLevel();
         BlockPos pos = tile.getBlockPos();
 
-        instance.effect(world, pos, this);
+        if(TotemicEventHooks.get().fireCeremonyEffectTick(world, pos, ceremony, instance, this))
+            instance.effect(world, pos, this);
         time++;
 
         if(!world.isClientSide) {

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateSelection.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateSelection.java
@@ -60,11 +60,15 @@ public final class StateSelection extends TotemState {
         tile.setChanged();
 
         if(selectors.size() >= CeremonyAPI.MIN_SELECTORS) {
-            Ceremony match = getCeremony(selectors);
-            if(match != null && !isDisabled(match, entity)) {
-                CeremonyInstance instance = match.createInstance();
-                if(instance.canSelect(tile.getLevel(), tile.getBlockPos(), entity)) {
-                    tile.setTotemState(new StateStartup(tile, match, instance, entity));
+            var eventResult = TotemicEventHooks.get().fireCeremonySelection(tile.getLevel(), tile.getBlockPos(), selectors,
+                    getCeremony(selectors));
+            Ceremony ceremony = eventResult.getFirst();
+            boolean doSelectionCheck = eventResult.getSecond();
+
+            if(ceremony != null && !isDisabled(ceremony, entity)) {
+                CeremonyInstance instance = ceremony.createInstance();
+                if(!doSelectionCheck || instance.canSelect(tile.getLevel(), tile.getBlockPos(), entity)) {
+                    tile.setTotemState(new StateStartup(tile, ceremony, instance, entity));
                 }
                 else
                     resetTotemState();
@@ -123,8 +127,7 @@ public final class StateSelection extends TotemState {
                     .collect(Collectors.toUnmodifiableMap(Ceremony::getSelectors, Function.identity()));
         }
 
-        return TotemicEventHooks.get().fireCeremonySelection(tile.getLevel(), tile.getBlockPos(), selectors,
-                selectorsToCeremonyMap.get(selectors));
+        return selectorsToCeremonyMap.get(selectors);
     }
 
     @Override

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateSelection.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateSelection.java
@@ -62,12 +62,12 @@ public final class StateSelection extends TotemState {
         if(selectors.size() >= CeremonyAPI.MIN_SELECTORS) {
             var eventResult = TotemicEventHooks.get().fireCeremonySelection(tile.getLevel(), tile.getBlockPos(), selectors,
                     getCeremony(selectors));
-            Ceremony ceremony = eventResult.getFirst();
-            boolean doSelectionCheck = eventResult.getSecond();
+            Ceremony ceremony = eventResult.first();
+            boolean skipSelectionCheck = eventResult.secondBoolean();
 
             if(ceremony != null && !isDisabled(ceremony, entity)) {
                 CeremonyInstance instance = ceremony.createInstance();
-                if(!doSelectionCheck || instance.canSelect(tile.getLevel(), tile.getBlockPos(), entity)) {
+                if(skipSelectionCheck || instance.canSelect(tile.getLevel(), tile.getBlockPos(), entity)) {
                     tile.setTotemState(new StateStartup(tile, ceremony, instance, entity));
                 }
                 else

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateSelection.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateSelection.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 import pokefenn.totemic.Totemic;
 import pokefenn.totemic.TotemicConfig;
+import pokefenn.totemic.TotemicEventHooks;
 import pokefenn.totemic.api.TotemicAPI;
 import pokefenn.totemic.api.ceremony.Ceremony;
 import pokefenn.totemic.api.ceremony.CeremonyAPI;
@@ -113,7 +114,7 @@ public final class StateSelection extends TotemState {
 
     private static Map<List<MusicInstrument>, Ceremony> selectorsToCeremonyMap; //Lazily created
 
-    private static @Nullable Ceremony getCeremony(List<MusicInstrument> selectors) {
+    private @Nullable Ceremony getCeremony(List<MusicInstrument> selectors) {
         if(selectorsToCeremonyMap == null) {
             //This will throw an exception if two different Ceremonies happen to have the same selectors.
             //Note that this check is not sufficient if MIN_SELECTORS != MAX_SELECTORS. In this case, we would have
@@ -122,7 +123,8 @@ public final class StateSelection extends TotemState {
                     .collect(Collectors.toUnmodifiableMap(Ceremony::getSelectors, Function.identity()));
         }
 
-        return selectorsToCeremonyMap.get(selectors);
+        return TotemicEventHooks.get().fireCeremonySelection(tile.getLevel(), tile.getBlockPos(), selectors,
+                selectorsToCeremonyMap.get(selectors));
     }
 
     @Override

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
@@ -85,10 +85,10 @@ public final class StateStartup extends TotemState implements StartupContext {
 
         if(!world.isClientSide) { //server side
             if(musicHandler.getTotalMusic() >= ceremony.getMusicNeeded()) {
-                if(instance.canStartEffect(world, pos, this))
+                if(instance.canStartEffect(world, pos, this) && TotemicEventHooks.get().fireCeremonyStartupSuccess(world, pos, ceremony, instance, this))
                     startCeremony();
                 else
-                    failCeremony();
+                    failCeremony(); //TODO: For 1.21.5, this else branch should be removed, to give the canStartEffect method the option to hold off on starting the effect without completely aborting the Ceremony
             }
             else if(time >= ceremony.getAdjustedMaxStartupTime(world.getDifficulty())) {
                 TotemicEventHooks.get().fireCeremonyStartupFail(world, pos, ceremony, instance, this);

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
@@ -109,8 +109,7 @@ public final class StateStartup extends TotemState implements StartupContext {
     }
 
     private void startupTick(Level world, BlockPos pos) {
-        TotemicEventHooks.get().fireCeremonyStartupTick(world, pos, ceremony, instance, this);
-        if(tile.getTotemState() == this) //make sure the startup hasn't been canceled by a handler of the above event
+        if(TotemicEventHooks.get().fireCeremonyStartupTick(world, pos, ceremony, instance, this))
             instance.onStartup(world, pos, this);
     }
 

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.network.PacketDistributor;
 import pokefenn.totemic.Totemic;
+import pokefenn.totemic.TotemicEventHooks;
 import pokefenn.totemic.advancements.ModCriteriaTriggers;
 import pokefenn.totemic.api.TotemicAPI;
 import pokefenn.totemic.api.TotemicEntityUtil;
@@ -82,7 +83,7 @@ public final class StateStartup extends TotemState implements StartupContext {
         Level world = tile.getLevel();
         BlockPos pos = tile.getBlockPos();
 
-        if(!world.isClientSide) {
+        if(!world.isClientSide) { //server side
             if(musicHandler.getTotalMusic() >= ceremony.getMusicNeeded()) {
                 if(instance.canStartEffect(world, pos, this))
                     startCeremony();
@@ -94,15 +95,22 @@ public final class StateStartup extends TotemState implements StartupContext {
                 failCeremony();
             }
             else {
-                instance.onStartup(world, pos, this);
+                startupTick(world, pos);
             }
         }
-        else {
-            instance.onStartup(world, pos, this); //do not change state based on time on the client side (to account for TPS lag)
+        else { //client side
+            //do not change state based on time on the client side (to account for TPS lag)
+            startupTick(world, pos);
             CeremonyHUD.INSTANCE.setActiveTotem(tile);
         }
 
         time++;
+    }
+
+    private void startupTick(Level world, BlockPos pos) {
+        TotemicEventHooks.get().fireCeremonyStartupTick(world, pos, ceremony, instance, this);
+        if(tile.getTotemState() == this) //make sure the startup hasn't been canceled by a handler of the above event
+            instance.onStartup(world, pos, this);
     }
 
     @Override

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateStartup.java
@@ -91,6 +91,7 @@ public final class StateStartup extends TotemState implements StartupContext {
                     failCeremony();
             }
             else if(time >= ceremony.getAdjustedMaxStartupTime(world.getDifficulty())) {
+                TotemicEventHooks.get().fireCeremonyStartupFail(world, pos, ceremony, instance, this);
                 instance.onStartupFail(world, pos, this);
                 failCeremony();
             }

--- a/src/main/java/pokefenn/totemic/block/totem/entity/StateTotemEffect.java
+++ b/src/main/java/pokefenn/totemic/block/totem/entity/StateTotemEffect.java
@@ -14,6 +14,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.network.PacketDistributor;
+import pokefenn.totemic.TotemicEventHooks;
 import pokefenn.totemic.api.music.MusicInstrument;
 import pokefenn.totemic.api.totem.TotemCarving;
 import pokefenn.totemic.api.totem.TotemEffectAPI;
@@ -37,8 +38,10 @@ public final class StateTotemEffect extends TotemState implements TotemEffectCon
         if(gameTime % tile.getCommonTotemEffectInterval() == 0) {
             for(var entry: tile.getTotemEffects().entrySet()) {
                 var effect = entry.getElement();
-                if(gameTime % effect.getInterval() == 0)
-                    effect.effect(level, tile.getBlockPos(), entry.getCount(), this);
+                int repetition = entry.getCount();
+                if(gameTime % effect.getInterval() == 0
+                        && TotemicEventHooks.get().fireTotemEffectEvent(level, tile.getBlockPos(), effect, repetition, this))
+                    effect.effect(level, tile.getBlockPos(), repetition, this);
             }
         }
 

--- a/src/main/java/pokefenn/totemic/item/CreativeMedicineBagItem.java
+++ b/src/main/java/pokefenn/totemic/item/CreativeMedicineBagItem.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
+import pokefenn.totemic.TotemicEventHooks;
 
 public class CreativeMedicineBagItem extends MedicineBagItem {
     public CreativeMedicineBagItem(Properties pProperties) {
@@ -23,7 +24,10 @@ public class CreativeMedicineBagItem extends MedicineBagItem {
             getEffects(stack).forEach(effect -> {
                 int interval = effect.getInterval();
                 if(level.getGameTime() % interval == 0) {
-                    effect.medicineBagEffect((Player) entity, stack, creativeChargeValue);
+                    var carving = getCarving(stack).get(); //Optional.get is safe since getEffects returned a non-empty list
+                    var player = (Player) entity;
+                    if(TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, creativeChargeValue))
+                        effect.medicineBagEffect(player, stack, creativeChargeValue);
                 }
             });
         }

--- a/src/main/java/pokefenn/totemic/item/CreativeMedicineBagItem.java
+++ b/src/main/java/pokefenn/totemic/item/CreativeMedicineBagItem.java
@@ -27,7 +27,7 @@ public class CreativeMedicineBagItem extends MedicineBagItem {
                     var carving = getCarving(stack).get(); //Optional.get is safe since getEffects returned a non-empty list
                     var player = (Player) entity;
                     var eventResult = TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, creativeChargeValue, 0);
-                    if(eventResult.rightBoolean())
+                    if(eventResult.secondBoolean())
                         effect.medicineBagEffect(player, stack, creativeChargeValue);
                 }
             });

--- a/src/main/java/pokefenn/totemic/item/CreativeMedicineBagItem.java
+++ b/src/main/java/pokefenn/totemic/item/CreativeMedicineBagItem.java
@@ -26,7 +26,8 @@ public class CreativeMedicineBagItem extends MedicineBagItem {
                 if(level.getGameTime() % interval == 0) {
                     var carving = getCarving(stack).get(); //Optional.get is safe since getEffects returned a non-empty list
                     var player = (Player) entity;
-                    if(TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, creativeChargeValue))
+                    var eventResult = TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, creativeChargeValue, 0);
+                    if(eventResult.rightBoolean())
                         effect.medicineBagEffect(player, stack, creativeChargeValue);
                 }
             });

--- a/src/main/java/pokefenn/totemic/item/MedicineBagItem.java
+++ b/src/main/java/pokefenn/totemic/item/MedicineBagItem.java
@@ -82,9 +82,11 @@ public class MedicineBagItem extends Item {
                     if(level.getGameTime() % interval == 0) {
                         var carving = getCarving(stack).get(); //Optional.get is safe since getEffects returned a non-empty list
                         var player = (Player) entity;
-                        if(TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, charge))
+                        var eventResult = TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, charge, interval);
+                        int chargeToDeduct = eventResult.firstInt();
+                        if(eventResult.rightBoolean())
                             effect.medicineBagEffect(player, stack, charge);
-                        stack.set(ModDataComponents.MEDICINE_BAG_CHARGE, Math.max(charge - interval, 0)); //TODO: This is called multiple times on carvings with multiple effects, which can be problematic especially when they have different intervals
+                        stack.set(ModDataComponents.MEDICINE_BAG_CHARGE, Math.max(charge - chargeToDeduct, 0)); //TODO: This is called multiple times on carvings with multiple effects, which can be problematic especially when they have different intervals
                     }
                 });
             }

--- a/src/main/java/pokefenn/totemic/item/MedicineBagItem.java
+++ b/src/main/java/pokefenn/totemic/item/MedicineBagItem.java
@@ -84,7 +84,7 @@ public class MedicineBagItem extends Item {
                         var player = (Player) entity;
                         var eventResult = TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, charge, interval);
                         int chargeToDeduct = eventResult.firstInt();
-                        if(eventResult.rightBoolean())
+                        if(eventResult.secondBoolean())
                             effect.medicineBagEffect(player, stack, charge);
                         stack.set(ModDataComponents.MEDICINE_BAG_CHARGE, Math.max(charge - chargeToDeduct, 0)); //TODO: This is called multiple times on carvings with multiple effects, which can be problematic especially when they have different intervals
                     }

--- a/src/main/java/pokefenn/totemic/item/MedicineBagItem.java
+++ b/src/main/java/pokefenn/totemic/item/MedicineBagItem.java
@@ -20,6 +20,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import pokefenn.totemic.Totemic;
+import pokefenn.totemic.TotemicEventHooks;
 import pokefenn.totemic.api.totem.MedicineBagEffect;
 import pokefenn.totemic.api.totem.PortableTotemCarving;
 import pokefenn.totemic.block.totem.entity.StateTotemEffect;
@@ -79,7 +80,10 @@ public class MedicineBagItem extends Item {
                 getEffects(stack).forEach(effect -> {
                     int interval = effect.getInterval();
                     if(level.getGameTime() % interval == 0) {
-                        effect.medicineBagEffect((Player) entity, stack, charge);
+                        var carving = getCarving(stack).get(); //Optional.get is safe since getEffects returned a non-empty list
+                        var player = (Player) entity;
+                        if(TotemicEventHooks.get().fireMedicineBagEffectEvent(effect, carving, player, stack, charge))
+                            effect.medicineBagEffect(player, stack, charge);
                         stack.set(ModDataComponents.MEDICINE_BAG_CHARGE, Math.max(charge - interval, 0)); //TODO: This is called multiple times on carvings with multiple effects, which can be problematic especially when they have different intervals
                     }
                 });

--- a/src/test/java/pokefenn/totemic/test/TestCeremonyEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestCeremonyEventHandlers.java
@@ -25,7 +25,7 @@ public class TestCeremonyEventHandlers {
     @SubscribeEvent
     public static void onStartupTick(CeremonyEvent.StartupTick event) {
         if(event.getContext().getTime() % 20 == 0)
-            Totemic.logger.debug("CeremonyEvent.StartupTick fired (time % 20 == 0)");
+            Totemic.logger.debug("CeremonyEvent.StartupTick fired (time = " + event.getContext().getTime() + ")");
     }
 
     @SubscribeEvent
@@ -39,6 +39,18 @@ public class TestCeremonyEventHandlers {
         Totemic.logger.debug("CeremonyEvent.StartupSuccess fired");
         if(false) {
             event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onEffectTick(CeremonyEvent.EffectTick event) {
+        if(event.getContext().getTime() % 20 == 0)
+            Totemic.logger.debug("CeremonyEvent.EffectTick fired (time = " + event.getContext().getTime() + ")");
+        if(event.getContext().getTime() >= 5*20) { //will stop the effect from applying after 5 seconds
+            event.setCanceled(true);
+        }
+        if(event.getContext().getTime() >= 10*20) { //will completely end the effect after 10 seconds
+            event.getContext().endCeremony();
         }
     }
 }

--- a/src/test/java/pokefenn/totemic/test/TestCeremonyEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestCeremonyEventHandlers.java
@@ -1,0 +1,44 @@
+package pokefenn.totemic.test;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import pokefenn.totemic.Totemic;
+import pokefenn.totemic.api.TotemicAPI;
+import pokefenn.totemic.api.event.CeremonyEvent;
+import pokefenn.totemic.init.ModContent;
+
+//Some event handlers that print log messages to allow manual testing of Ceremony events.
+@EventBusSubscriber(modid = TotemicAPI.MOD_ID)
+public class TestCeremonyEventHandlers {
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public static void onSelection(CeremonyEvent.Selection event) {
+        Totemic.logger.debug("CeremonyEvent.Selection fired: " + event.getCeremony());
+        if(false) { //modify me in dev
+            event.setCanceled(true);
+        }
+        if(false) {
+            event.setCeremony(ModContent.war_dance.get());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onStartupTick(CeremonyEvent.StartupTick event) {
+        if(event.getContext().getTime() % 20 == 0)
+            Totemic.logger.debug("CeremonyEvent.StartupTick fired (time % 20 == 0)");
+    }
+
+    @SubscribeEvent
+    public static void onStartupFail(CeremonyEvent.StartupFail event) {
+        Totemic.logger.debug("CeremonyEvent.StartupFail fired");
+    }
+
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public static void onStartupSuccess(CeremonyEvent.StartupSuccess event) {
+        Totemic.logger.debug("CeremonyEvent.StartupSuccess fired");
+        if(false) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/test/java/pokefenn/totemic/test/TestCeremonyEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestCeremonyEventHandlers.java
@@ -5,27 +5,22 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import pokefenn.totemic.Totemic;
 import pokefenn.totemic.api.TotemicAPI;
 import pokefenn.totemic.api.event.CeremonyEvent;
-import pokefenn.totemic.init.ModContent;
 
 //Some event handlers that print log messages to allow manual testing of Ceremony events.
 @EventBusSubscriber(modid = TotemicAPI.MOD_ID)
 public class TestCeremonyEventHandlers {
-    @SuppressWarnings("unused")
     @SubscribeEvent
     public static void onSelection(CeremonyEvent.Selection event) {
-        Totemic.logger.debug("CeremonyEvent.Selection fired: " + event.getCeremony());
-        if(false) { //modify me in dev
-            event.setCanceled(true);
-        }
-        if(false) {
-            event.setCeremony(ModContent.war_dance.get());
-        }
+        Totemic.logger.debug("CeremonyEvent.Selection fired: {}" , event.getCeremony());
+        //event.setCanceled(true);
+        //event.setCeremony(null);
+        //event.setCeremony(ModContent.buffalo_dance.get());
     }
 
     @SubscribeEvent
     public static void onStartupTick(CeremonyEvent.StartupTick event) {
         if(event.getContext().getTime() % 20 == 0)
-            Totemic.logger.debug("CeremonyEvent.StartupTick fired (time = " + event.getContext().getTime() + ")");
+            Totemic.logger.debug("CeremonyEvent.StartupTick fired (time = {})", event.getContext().getTime());
     }
 
     @SubscribeEvent
@@ -33,19 +28,16 @@ public class TestCeremonyEventHandlers {
         Totemic.logger.debug("CeremonyEvent.StartupFail fired");
     }
 
-    @SuppressWarnings("unused")
     @SubscribeEvent
     public static void onStartupSuccess(CeremonyEvent.StartupSuccess event) {
         Totemic.logger.debug("CeremonyEvent.StartupSuccess fired");
-        if(false) {
-            event.setCanceled(true);
-        }
+        event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onEffectTick(CeremonyEvent.EffectTick event) {
         if(event.getContext().getTime() % 20 == 0)
-            Totemic.logger.debug("CeremonyEvent.EffectTick fired (time = " + event.getContext().getTime() + ")");
+            Totemic.logger.debug("CeremonyEvent.EffectTick fired (time = {})", event.getContext().getTime());
         if(event.getContext().getTime() >= 5*20) { //will stop the effect from applying after 5 seconds
             event.setCanceled(true);
         }

--- a/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
@@ -5,6 +5,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import pokefenn.totemic.Totemic;
 import pokefenn.totemic.api.TotemicAPI;
 import pokefenn.totemic.api.event.CeremonyEvent;
+import pokefenn.totemic.api.event.MedicineBagEffectEvent;
 import pokefenn.totemic.api.event.TotemEffectEvent;
 
 //Some event handlers that print log messages to allow manual testing of Totemic events.
@@ -54,5 +55,12 @@ public class TestEventHandlers {
         //Totemic.logger.debug("TotemEffectEvent fired (effect = {}, carving = {}, rep = {}, pos = {})", event.getEffect(), event.getCarving(), event.getRepetition(), event.getPos());
         /*if(event.getCarving() == ModContent.ocelot.get())
             event.setCanceled(true);*/
+        if(!event.getCarving().getEffects().contains(event.getEffect()))
+            Totemic.logger.error("Carving {} does not contain TotemEffect {}", event.getCarving(), event.getEffect());
+    }
+
+    @SubscribeEvent
+    public static void onMedicineBagEffectTick(MedicineBagEffectEvent event) {
+        Totemic.logger.debug("MedicineBagEffectEvent fired (effect = {}, carving = {}, charge = {})", event.getEffect(), event.getCarving(), event.getCharge());
     }
 }

--- a/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
@@ -42,12 +42,12 @@ public class TestEventHandlers {
     public static void onEffectTick(CeremonyEvent.EffectTick event) {
         if(event.getContext().getTime() % 20 == 0)
             Totemic.logger.debug("CeremonyEvent.EffectTick fired (time = {})", event.getContext().getTime());
-        if(event.getContext().getTime() >= 5*20) { //will stop the effect from applying after 5 seconds
+        /*if(event.getContext().getTime() >= 5*20) { //will stop the effect from applying after 5 seconds
             event.setCanceled(true);
-        }
-        if(event.getContext().getTime() >= 10*20) { //will completely end the effect after 10 seconds
+        }*/
+        /*if(event.getContext().getTime() >= 10*20) { //will completely end the effect after 10 seconds
             event.getContext().endCeremony();
-        }
+        }*/
     }
 
     @SubscribeEvent
@@ -61,6 +61,9 @@ public class TestEventHandlers {
 
     @SubscribeEvent
     public static void onMedicineBagEffectTick(MedicineBagEffectEvent event) {
-        Totemic.logger.debug("MedicineBagEffectEvent fired (effect = {}, carving = {}, charge = {})", event.getEffect(), event.getCarving(), event.getCharge());
+        Totemic.logger.debug("MedicineBagEffectEvent fired (effect = {}, carving = {}, charge = {}, deduct = {})", event.getEffect(), event.getCarving(), event.getCharge(), event.getChargeToDeduct());
+        //event.setCanceled(true);
+        /*if(!event.getPlayer().level().isClientSide)
+            event.setChargeToDeduct(10);*/
     }
 }

--- a/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
@@ -23,6 +23,7 @@ public class TestEventHandlers {
     public static void onStartupTick(CeremonyEvent.StartupTick event) {
         if(event.getContext().getTime() % 20 == 0)
             Totemic.logger.debug("CeremonyEvent.StartupTick fired (time = {})", event.getContext().getTime());
+        //event.setCanceled(true);
         //event.getContext().startCeremony();
         //event.getContext().failCeremony();
     }

--- a/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
@@ -5,10 +5,11 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import pokefenn.totemic.Totemic;
 import pokefenn.totemic.api.TotemicAPI;
 import pokefenn.totemic.api.event.CeremonyEvent;
+import pokefenn.totemic.api.event.TotemEffectEvent;
 
-//Some event handlers that print log messages to allow manual testing of Ceremony events.
+//Some event handlers that print log messages to allow manual testing of Totemic events.
 @EventBusSubscriber(modid = TotemicAPI.MOD_ID)
-public class TestCeremonyEventHandlers {
+public class TestEventHandlers {
     @SubscribeEvent
     public static void onSelection(CeremonyEvent.Selection event) {
         Totemic.logger.debug("CeremonyEvent.Selection fired: {}" , event.getCeremony());
@@ -21,6 +22,8 @@ public class TestCeremonyEventHandlers {
     public static void onStartupTick(CeremonyEvent.StartupTick event) {
         if(event.getContext().getTime() % 20 == 0)
             Totemic.logger.debug("CeremonyEvent.StartupTick fired (time = {})", event.getContext().getTime());
+        //event.getContext().startCeremony();
+        //event.getContext().failCeremony();
     }
 
     @SubscribeEvent
@@ -31,7 +34,7 @@ public class TestCeremonyEventHandlers {
     @SubscribeEvent
     public static void onStartupSuccess(CeremonyEvent.StartupSuccess event) {
         Totemic.logger.debug("CeremonyEvent.StartupSuccess fired");
-        event.setCanceled(true);
+        //event.setCanceled(true);
     }
 
     @SubscribeEvent
@@ -44,5 +47,12 @@ public class TestCeremonyEventHandlers {
         if(event.getContext().getTime() >= 10*20) { //will completely end the effect after 10 seconds
             event.getContext().endCeremony();
         }
+    }
+
+    @SubscribeEvent
+    public static void onTotemEffectTick(TotemEffectEvent event) {
+        //Totemic.logger.debug("TotemEffectEvent fired (effect = {}, carving = {}, rep = {}, pos = {})", event.getEffect(), event.getCarving(), event.getRepetition(), event.getPos());
+        /*if(event.getCarving() == ModContent.ocelot.get())
+            event.setCanceled(true);*/
     }
 }

--- a/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
+++ b/src/test/java/pokefenn/totemic/test/TestEventHandlers.java
@@ -14,7 +14,7 @@ public class TestEventHandlers {
     @SubscribeEvent
     public static void onSelection(CeremonyEvent.Selection event) {
         Totemic.logger.debug("CeremonyEvent.Selection fired: {}" , event.getCeremony());
-        //event.setCanceled(true);
+        //event.setSkipSelectionCheck(true);
         //event.setCeremony(null);
         //event.setCeremony(ModContent.buffalo_dance.get());
     }


### PR DESCRIPTION
Adds various events to the API (eventually for Ceremonies, Totem Effects and music playing). This is meant as a precursor for adding KubeJS and/or CraftTweaker integration for Totemic.